### PR TITLE
Merge some pending pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 Changelog
 =========
+6.0.3 - 2020-04-13
+------------------
+
+- Implemented BiometricPrompt#setDeviceCredentialAllowed for API 29 and above - [PR #21](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/21)
+- Added KeyPermanentlyInvalidatedException handling - [PR #28](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/28)
+- public store method for other plugin use - [PR #33](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/33)
+- Added retro-compatibility option for data encrypted with old cipher - [PR #36](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/36)
+- fix: further guard against NPEs - [PR #40](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/40)
+- Fix to storage getting wiped after restarting app with Ionic - [PR #41](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/41)
+
 6.0.2 - 2020-03-23
 ------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 Changelog
 =========
+6.0.2 - 2020-03-23
+------------------
+
+- Repackage as cordova-plugin-secure-storage-android10.
+  [Sotam]
 
 5.0.1 - 2019-11-25
 ------------------

--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ ss.set(
 );
 ```
 
-When reading value, the same cypher mode will be applied.  
+When reading value, the same cypher mode will be applied.
+
+This can also be useful when reading value from encrypted by another App, that use AES GCM cypher mode.  
 
 #### Windows
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,22 @@ Changing the lock screen type on Android erases the keystore (issues [61989](htt
 
 This means that any values saved using the plugin could be lost if the user changes security settings. The plugin should therefore be used as a secure credential cache and not persistent storage on Android.
 
+##### Android AES crypher mode
+
+An optional parameter `cypherMode` can be used, for `set()`, to select a specific AES cypher mode, to encrypt: 
+```js
+ss.set(
+  function(key) {/*success*/},
+  function(error) {{/*error*/},
+  "mykey",
+  "myvalue",
+   // cypherMode: "CCM" (default) or "GCM" (Galois/Counter Mode)
+  "CCM"
+);
+```
+
+When reading value, the same cypher mode will be applied.  
+
 #### Windows
 
 Windows implementation is based on [PasswordVault](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.passwordvault.aspx) object from the [Windows.Security.Credentials](https://msdn.microsoft.com/en-us/library/windows/apps/windows.security.credentials.aspx) namespace.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage-android10",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Secure storage plugin for iOS & Android 10 (backwards compatible with Android 9)",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-secure-storage-android10",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Secure storage plugin for iOS & Android 10 (backwards compatible with Android 9)",
   "author": "Yiorgis Gozadinos <ggozad@crypho.com>",
   "contributors": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage-android10"
-    version="6.0.3">
+    version="6.0.4">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>
@@ -57,6 +57,11 @@
         <source-file src="src/android/RSA.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/AES.java" target-dir="src/com/crypho/plugins/" />
         <source-file src="src/android/SharedPreferencesHandler.java" target-dir="src/com/crypho/plugins/" />
+
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+            <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+        </config-file>
     </platform>
 
     <platform name="browser">
@@ -72,5 +77,4 @@
             <runs />
         </js-module>
     </platform>
-
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-secure-storage-echo"
-    version="5.0.1">
+    id="cordova-plugin-secure-storage-android10"
+    version="6.0.2">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-secure-storage-android10"
-    version="6.0.2">
+    version="6.0.3">
 
     <name>SecureStorage</name>
     <author>Crypho AS</author>

--- a/src/android/AES.java
+++ b/src/android/AES.java
@@ -16,16 +16,16 @@ public class AES {
     private static final String CIPHER_MODE = "CCM";
     private static final int KEY_SIZE = 256;
     private static final int VERSION = 1;
-    private static final Cipher CIPHER = getCipher();
+    private static final Cipher GLOBAL_CIPHER = getCipher(CIPHER_MODE);
 
     public static JSONObject encrypt(byte[] msg, byte[] adata) throws Exception {
         byte[] iv, ct, secretKeySpec_enc;
-        synchronized (CIPHER) {
+        synchronized (GLOBAL_CIPHER) {
             SecretKeySpec secretKeySpec = generateKeySpec();
             secretKeySpec_enc = secretKeySpec.getEncoded();
-            initCipher(Cipher.ENCRYPT_MODE, secretKeySpec, null, adata);
-            iv = CIPHER.getIV();
-            ct = CIPHER.doFinal(msg);
+            initCipher(Cipher.ENCRYPT_MODE, secretKeySpec, null, adata, GLOBAL_CIPHER);
+            iv = GLOBAL_CIPHER.getIV();
+            ct = GLOBAL_CIPHER.doFinal(msg);
         }
 
         JSONObject value = new JSONObject();
@@ -45,11 +45,17 @@ public class AES {
         return result;
     }
 
-    public static String decrypt(byte[] buf, byte[] key, byte[] iv, byte[] adata) throws Exception {
+    public static String decrypt(byte[] buf, byte[] key, byte[] iv, byte[] adata, String cipherMode) throws Exception {
+        Cipher cipher;
+        if ( cipherMode == CIPHER_MODE ) {
+            cipher = GLOBAL_CIPHER;
+        } else {
+            cipher = getCipher(cipherMode);
+        }
         SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
-        synchronized (CIPHER) {
-            initCipher(Cipher.DECRYPT_MODE, secretKeySpec, iv, adata);
-            return new String(CIPHER.doFinal(buf));
+        synchronized (cipher) {
+            initCipher(Cipher.DECRYPT_MODE, secretKeySpec, iv, adata, cipher);
+            return new String(cipher.doFinal(buf));
         }
     }
 
@@ -60,18 +66,22 @@ public class AES {
         return new SecretKeySpec(sc.getEncoded(), "AES");
     }
 
-    private static void initCipher(int cipherMode, Key key, byte[] iv, byte[] adata) throws Exception {
+    private static void initCipher(int cipherMode, Key key, byte[] iv, byte[] adata, Cipher cipher) throws Exception {
         if (iv != null) {
-            CIPHER.init(cipherMode, key, new IvParameterSpec(iv));
+            cipher.init(cipherMode, key, new IvParameterSpec(iv));
         } else {
-            CIPHER.init(cipherMode, key);
+            cipher.init(cipherMode, key);
         }
-        CIPHER.updateAAD(adata);
+        cipher.updateAAD(adata);
     }
 
-    private static Cipher getCipher() {
+    private static Cipher getCipher(String cipherMode) {
+	    if ( cipherMode == null ) {
+	        cipherMode = CIPHER_MODE;
+	    }
+
         try {
-            return Cipher.getInstance("AES/" + CIPHER_MODE + "/NoPadding");
+            return Cipher.getInstance("AES/" + cipherMode + "/NoPadding");
         } catch (Exception e) {
             return null;
         }

--- a/src/android/AbstractRSA.java
+++ b/src/android/AbstractRSA.java
@@ -3,6 +3,7 @@ package com.crypho.plugins;
 import android.content.Context;
 import android.os.Build;
 import android.security.keystore.KeyProperties;
+import android.util.Log;
 
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -95,6 +96,16 @@ public abstract class AbstractRSA {
         return key;
     }
 
+    private void deleteKey(String alias) {
+		try {
+			KeyStore keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER);
+			keyStore.load(null, null);
+			keyStore.deleteEntry(alias);
+		} catch (Exception e) {
+			Log.e(TAG, "Exception deleting key", e);
+		}
+    }
+
     boolean userAuthenticationRequired(String alias) {
         try {
             // Do a quick encrypt/decrypt test
@@ -102,6 +113,7 @@ public abstract class AbstractRSA {
             decrypt(encrypted, alias);
             return false;
         } catch (InvalidKeyException noAuthEx) {
+            deleteKey(alias);
             return true;
         } catch (Exception e) {
             // Other

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -55,12 +55,14 @@ public class SecureStorage extends CordovaPlugin {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 cordova.getThreadPool().execute(new Runnable() {
                     public void run() {
-                        String alias = service2alias(INIT_SERVICE);
-                        if (rsa.userAuthenticationRequired(alias)) {
-                            unlockCredentialsContext.error("User not authenticated");
+                        if (unlockCredentialsContext != null) {
+                            String alias = service2alias(INIT_SERVICE);
+                            if (rsa.userAuthenticationRequired(alias)) {
+                                unlockCredentialsContext.error("User not authenticated");
+                            }
+                            unlockCredentialsContext.success();
+                            unlockCredentialsContext = null;
                         }
-                        unlockCredentialsContext.success();
-                        unlockCredentialsContext = null;
                     }
                 });
             }

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -133,14 +133,16 @@ public class SecureStorage extends CordovaPlugin {
             final String service = args.getString(0);
             final String key = args.getString(1);
             final String value = args.getString(2);
+            final String cypherMode = args.getString(3);
             final String adata = service;
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     try {
-                        JSONObject result = AES.encrypt(value.getBytes(), adata.getBytes());
+                        JSONObject result = AES.encrypt(value.getBytes(), adata.getBytes(), cypherMode);
                         byte[] aes_key = Base64.decode(result.getString("key"), Base64.DEFAULT);
                         byte[] aes_key_enc = rsa.encrypt(aes_key, service2alias(service));
                         result.put("key", Base64.encodeToString(aes_key_enc, Base64.DEFAULT));
+                        if (cypherMode != null) result.put("mode", cypherMode);
                         getStorage(service).store(key, result.toString());
                         callbackContext.success(key);
                     } catch (Exception e) {

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -160,7 +160,7 @@ public class SecureStorage extends CordovaPlugin {
                     public void run() {
                         try {
                             byte[] decryptedKey = rsa.decrypt(encKey, service2alias(service));
-                            String decrypted = new String(AES.decrypt(ct, decryptedKey, iv, adata));
+                            String decrypted = new String(AES.decrypt(ct, decryptedKey, iv, adata, data.getString("mode")));
                             callbackContext.success(decrypted);
                         } catch (Exception e) {
                             Log.e(TAG, "Decrypt failed :", e);

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -4,11 +4,13 @@ import android.annotation.TargetApi;
 import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.hardware.biometrics.BiometricPrompt;
 import android.os.Build;
+import android.os.CancellationSignal;
+import android.os.Handler;
 import android.provider.Settings;
 import android.util.Base64;
 import android.util.Log;
-import android.hardware.biometrics;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -20,6 +22,7 @@ import org.json.JSONObject;
 import java.lang.reflect.Method;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 public class SecureStorage extends CordovaPlugin {
     private static final String TAG = "SecureStorage";
@@ -155,7 +158,7 @@ public class SecureStorage extends CordovaPlugin {
             if (value != null) {
                 JSONObject json = new JSONObject(value);
                 final byte[] encKey = Base64.decode(json.getString("key"), Base64.DEFAULT);
-                JSONObject data = json.getJSONObject("value");
+                final JSONObject data = json.getJSONObject("value");
                 final byte[] ct = Base64.decode(data.getString("ct"), Base64.DEFAULT);
                 final byte[] iv = Base64.decode(data.getString("iv"), Base64.DEFAULT);
                 final byte[] adata = Base64.decode(data.getString("adata"), Base64.DEFAULT);
@@ -244,7 +247,7 @@ public class SecureStorage extends CordovaPlugin {
                     BiometricPrompt.Builder biometricPromptBuilder = new BiometricPrompt.Builder(getContext());
                     biometricPromptBuilder.setTitle(title);
                     biometricPromptBuilder.setDescription(description);
-                    biometricPromptBuilder.setDeviceCredentialAllowed(true);
+                    //biometricPromptBuilder.setDeviceCredentialAllowed(true);
                     BiometricPrompt biometricPrompt = biometricPromptBuilder.build();
                     CancellationSignal cancellationSignal = new CancellationSignal();
                     final Executor executor = getExecutor();
@@ -301,7 +304,7 @@ public class SecureStorage extends CordovaPlugin {
      *
      * @param userAuthenticationValidityDuration User authentication validity duration in seconds
      */
-    private void generateEncryptionKeys(Integer userAuthenticationValidityDuration) {
+    private void generateEncryptionKeys(final Integer userAuthenticationValidityDuration) {
         if (generateKeysContext != null && !generateKeysContextRunning) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {

--- a/src/android/SecureStorage.java
+++ b/src/android/SecureStorage.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 
 import java.lang.reflect.Method;
 import java.util.Hashtable;
+import java.util.Map;
 
 public class SecureStorage extends CordovaPlugin {
     private static final String TAG = "SecureStorage";
@@ -300,16 +301,19 @@ public class SecureStorage extends CordovaPlugin {
      *
      * @param userAuthenticationValidityDuration User authentication validity duration in seconds
      */
-    private void generateEncryptionKeys(final Integer userAuthenticationValidityDuration) {
+    private void generateEncryptionKeys(Integer userAuthenticationValidityDuration) {
         if (generateKeysContext != null && !generateKeysContextRunning) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     generateKeysContextRunning = true;
                     try {
                         String alias = service2alias(INIT_SERVICE);
-                        //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
-                        getStorage(INIT_SERVICE).clear();
-                        rsa.createKeyPair(getContext(), alias, userAuthenticationValidityDuration);
+                        SharedPreferencesHandler storage = getStorage(INIT_SERVICE);
+                        if(storage.isEmpty()){
+                            //Solves Issue #96. The RSA key may have been deleted by changing the lock type.
+                            getStorage(INIT_SERVICE).clear();
+                            rsa.createKeyPair(getContext(), alias, userAuthenticationValidityDuration);
+                        }
                         generateKeysContext.success();
                     } catch (Exception e) {
                         Log.e(TAG, MSG_KEYS_FAILED, e);

--- a/src/android/SharedPreferencesHandler.java
+++ b/src/android/SharedPreferencesHandler.java
@@ -14,7 +14,7 @@ public class SharedPreferencesHandler {
 		prefs = ctx.getSharedPreferences(prefsName  + "_SS", 0);
 	}
 
-    void store(String key, String value){
+    public void store(String key, String value){
         SharedPreferences.Editor editor = prefs.edit();
         editor.putString("_SS_" + key, value);
         editor.commit();

--- a/src/android/SharedPreferencesHandler.java
+++ b/src/android/SharedPreferencesHandler.java
@@ -20,6 +20,11 @@ public class SharedPreferencesHandler {
         editor.commit();
     }
 
+    boolean isEmpty() {
+        int numOfPrefs = prefs.getAll().size();
+        return (numOfPrefs == 0);
+    }
+
     String fetch (String key){
         return prefs.getString("_SS_" + key, null);
     }


### PR DESCRIPTION
- Implemented BiometricPrompt#setDeviceCredentialAllowed for API 29 and above - [PR #21](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/21)
- Added KeyPermanentlyInvalidatedException handling - [PR #28](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/28)
- public store method for other plugin use - [PR #33](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/33)
- Added retro-compatibility option for data encrypted with old cipher - [PR #36](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/36)
- fix: further guard against NPEs - [PR #40](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/40)
- Fix to storage getting wiped after restarting app with Ionic - [PR #41](https://github.com/mibrito707/cordova-plugin-secure-storage-echo/pull/41)
